### PR TITLE
Bump dependency to minimal Yojson version

### DIFF
--- a/wamp-yojson.opam
+++ b/wamp-yojson.opam
@@ -12,6 +12,6 @@ available: [ ocaml-version >= "4.03.0" ]
 depends: [
   "jbuilder" {build & >= "1.0+beta8"}
   "wamp" {= "1.2"}
-  "yojson" {>= "1.3.3"}
+  "yojson" {>= "1.6.0"}
 ]
 build: [ "jbuilder" "build" "-j" jobs "-p" name "@install" ]


### PR DESCRIPTION
This code fortunately already uses the `t` type that Yojson migrated to but the minimum constraint is too low: it was only added in `1.6.0`.

This PR adjusts the minimum constraint.